### PR TITLE
Bumped the base image from Debian Bullseye to Bookworm and modernised everything around it

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -5,44 +5,37 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Login to GitHub Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
 
-      - name: set lower case repository
-        run: |
-          echo "REPO_LC=${REPO,,}" >>${GITHUB_ENV}
-        env:
-          REPO: '${{ github.repository }}'
-
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          # list of Docker images to use as base name for tags
           images: |
-            ${{ env.REPO_LC }}
-          # generate Docker tags based on the following events/attributes
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}
           tags: |
             type=raw,value=dev
-          # always generate latest tag on push
 
-      - name: Build and push to DockerHub
-        id: docker_build
-        uses: docker/build-push-action@v4
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
           push: true
-          tags: |
-            ghcr.io/${{ env.REPO_LC }}/${{ github.event.repository.name }}:dev
-            ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/monthly_build.yml
+++ b/.github/workflows/monthly_build.yml
@@ -1,5 +1,5 @@
-name: schedule build
-on: 
+name: Scheduled build
+on:
   schedule:
     - cron: "0 0 1,15 * *"
 
@@ -7,49 +7,39 @@ jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: 'latest'
 
-      - run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV #Fix https://github.community/t/repository-name-in-environment-variable/16856/6
-        shell: bash
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Login to GitHub Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
 
-      - name: set lower case repository
-        run: |
-          echo "REPO_LC=${REPO,,}" >>${GITHUB_ENV}
-        env:
-          REPO: '${{ github.repository }}'
-
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          # list of Docker images to use as base name for tags
           images: |
-            ${{ env.REPO_LC }}
-          # generate Docker tags based on the following events/attributes
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}
           tags: |
             type=raw,value=latest
-          # always generate latest tag on push
 
-      - name: Build and push to DockerHub
-        id: docker_build
-        uses: docker/build-push-action@v4
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
           push: true
-          tags: |
-            ghcr.io/${{ env.REPO_LC }}/${{ env.REPOSITORY_NAME }}:latest
-            ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 name: Release
-on: 
+on:
   release:
     types: [published]
 
@@ -7,16 +7,19 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -24,7 +27,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: |
@@ -38,9 +41,11 @@ jobs:
           # always generate latest tag on push
           flavor: |
             latest=true
+
       - name: Build and push to DockerHub & GitHub Packages
         id: docker_build
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           push: true
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,53 +1,41 @@
-name: Gitub action test
+name: GitHub action test
 on: workflow_dispatch
 
 jobs:
   push:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: 'latest'
+      - uses: actions/checkout@v4
 
-      - run: echo "REPOSITORY_NAME=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')" >> $GITHUB_ENV #Fix https://github.community/t/repository-name-in-environment-variable/16856/6
-        shell: bash
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      
+
       - name: Login to GitHub Packages
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GHCR_PAT }}
 
-      - name: set lower case repository
-        run: |
-          echo "REPO_LC=${REPO,,}" >>${GITHUB_ENV}
-        env:
-          REPO: '${{ github.repository }}'
-
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
-          # list of Docker images to use as base name for tags
           images: |
-            ${{ env.REPO_LC }}
-          # generate Docker tags based on the following events/attributes
+            ${{ github.repository }}
+            ghcr.io/${{ github.repository }}/${{ github.event.repository.name }}
           tags: |
             type=raw,value=latest
-          # always generate latest tag on push
 
-      - name: Build and push to DockerHub
-        id: docker_build
-        uses: docker/build-push-action@v4
+      - name: Build and push
+        uses: docker/build-push-action@v6
         with:
           push: true
-          tags: |
-            ghcr.io/${{ env.REPO_LC }}/${{ env.REPOSITORY_NAME }}:latest
-            ${{ steps.meta.outputs.tags }}
+          platforms: linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,48 +1,40 @@
 ############################################################
 # Dockerfile that contains SteamCMD
 ############################################################
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 LABEL maintainer="donimax@mdoni.de"
 ARG PUID=1000
 
-ENV USER steam
-ENV HOMEDIR "/home/${USER}"
-ENV STEAMCMDDIR "${HOMEDIR}/steamcmd"
+ENV USER=steam
+ENV HOMEDIR="/home/${USER}"
+ENV STEAMCMDDIR="${HOMEDIR}/steamcmd"
 
-# Install, update & upgrade packages
-# Create user for the server
-# This also creates the home directory we later need
-# Clean TMP, apt-get cache and other stuff to make the image smaller
-# Create Directory for SteamCMD
-# Download SteamCMD
-# Extract and delete archive
 RUN set -x \
-	&& echo "deb http://deb.debian.org/debian bullseye contrib non-free" >> /etc/apt/sources.list \
+	&& echo "deb http://deb.debian.org/debian bookworm contrib non-free non-free-firmware" > /etc/apt/sources.list.d/non-free.list \
 	&& apt-get update \
 	&& apt-get upgrade -y \
 	&& apt-get install -y --no-install-recommends --no-install-suggests \
 		lib32stdc++6 \
 		lib32gcc-s1 \
-		wget \
-		ca-certificates \
 		curl \
+		ca-certificates \
 		locales \
 		procps \
 	&& sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
 	&& dpkg-reconfigure --frontend=noninteractive locales \
 	&& useradd -u "${PUID}" -m "${USER}" \
-		&& su "${USER}" -c \
-			"mkdir -p \"${STEAMCMDDIR}\" \
-			&& wget -qO- 'https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz' | tar xvzf - -C \"${STEAMCMDDIR}\" \
-			&& \"./${STEAMCMDDIR}/steamcmd.sh\" +quit \
-			&& mkdir -p \"${HOMEDIR}/.steam/sdk32\" \
-			&& ln -s \"${STEAMCMDDIR}/linux32/steamclient.so\" \"${HOMEDIR}/.steam/sdk32/steamclient.so\" \
+	&& su "${USER}" -c \
+		"mkdir -p \"${STEAMCMDDIR}\" \
+		&& curl -sqL 'https://steamcdn-a.akamaihd.net/client/installer/steamcmd_linux.tar.gz' | tar xvzf - -C \"${STEAMCMDDIR}\" \
+		&& \"${STEAMCMDDIR}/steamcmd.sh\" +quit \
+		&& mkdir -p \"${HOMEDIR}/.steam/sdk32\" \
+		&& ln -s \"${STEAMCMDDIR}/linux32/steamclient.so\" \"${HOMEDIR}/.steam/sdk32/steamclient.so\" \
+		&& mkdir -p \"${HOMEDIR}/.steam/sdk64\" \
+		&& ln -s \"${STEAMCMDDIR}/linux64/steamclient.so\" \"${HOMEDIR}/.steam/sdk64/steamclient.so\" \
 		&& ln -s \"${STEAMCMDDIR}/linux32/steamcmd\" \"${STEAMCMDDIR}/linux32/steam\" \
 		&& ln -s \"${STEAMCMDDIR}/steamcmd.sh\" \"${STEAMCMDDIR}/steam.sh\"" \
 	&& ln -s "${STEAMCMDDIR}/linux64/steamclient.so" "/usr/lib/x86_64-linux-gnu/steamclient.so" \
-	&& apt-get remove --purge -y \
-		wget \
 	&& apt-get clean autoclean \
 	&& apt-get autoremove -y \
 	&& rm -rf /var/lib/apt/lists/*
@@ -51,6 +43,10 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US:en
 ENV LC_ALL=en_US.UTF-8
 
+USER ${USER}
+
 WORKDIR ${STEAMCMDDIR}
 
 VOLUME ${STEAMCMDDIR}
+
+ENTRYPOINT ["./steamcmd.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV HOMEDIR="/home/${USER}"
 ENV STEAMCMDDIR="${HOMEDIR}/steamcmd"
 
 RUN set -x \
-	&& echo "deb http://deb.debian.org/debian bookworm contrib non-free non-free-firmware" > /etc/apt/sources.list.d/non-free.list \
+	&& sed -i 's/^Components: main$/Components: main contrib non-free non-free-firmware/' /etc/apt/sources.list.d/debian.sources \
 	&& dpkg --add-architecture i386 \
 	&& apt-get update \
 	&& apt-get upgrade -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV STEAMCMDDIR="${HOMEDIR}/steamcmd"
 
 RUN set -x \
 	&& echo "deb http://deb.debian.org/debian bookworm contrib non-free non-free-firmware" > /etc/apt/sources.list.d/non-free.list \
+	&& dpkg --add-architecture i386 \
 	&& apt-get update \
 	&& apt-get upgrade -y \
 	&& apt-get install -y --no-install-recommends --no-install-suggests \


### PR DESCRIPTION
   **Dockerfile**
   - Base image: `debian:bullseye-slim` → `debian:bookworm-slim`
   - Enable `contrib`, `non-free`, and `non-free-firmware` components via Bookworm's new DEB822 sources format
   - Added `dpkg --add-architecture i386` for 32-bit library support
   - Replaced `wget` with `curl` (already in the image — no need for a second download tool)
   - Added missing `sdk64` symlink so 64-bit games find the steamclient
   - Dropped the install-then-purge `wget` dance; just don't install it
   - Switched `ENV` to the modern `KEY=value` syntax
   - Added `USER steam` before `WORKDIR` so the container doesn't run as root
   - Added `ENTRYPOINT ["./steamcmd.sh"]` for a sensible default command

**GitHub Actions**
   - Bumped action versions
   - Removed the clunky lowercase-repo workaround — `${{ github.repository }}` is already lowercase in image references
   - Fixed typo in test workflow name ("Gitub" → "GitHub")
   - Removed hardcoded `ref: 'latest'` from the test workflow so it builds the current branch